### PR TITLE
fix: 파일 읽기 실패 시 에러 메시지 undefined 표시 문제 수정

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -281,7 +281,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const reader = new FileReader();
         reader.readAsDataURL(file);
         reader.onload = () => resolve({ base64: reader.result.split(',')[1], type: file.type, name: file.name });
-        reader.onerror = error => reject(error);
+        reader.onerror = () => reject(reader.error || new Error('파일 읽기 실패: ' + (file && file.name)));
     });
 
     const combinePads = (namePad, signaturePad) => new Promise((resolve, reject) => {
@@ -1142,7 +1142,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 throw new Error(result.message);
             }
         } catch (error) {
-            alert('오류가 발생했습니다: ' + error.message);
+            const msg = (error && (error.message || error.name)) || String(error);
+            console.error('제출 오류:', error);
+            alert('오류가 발생했습니다: ' + msg);
             submitBtn.disabled = false;
         } finally {
             loadingModal.classList.add('hidden');


### PR DESCRIPTION
FileReader.onerror가 ProgressEvent를 reject하여 catch에서 error.message가 undefined로 노출되던 문제를 수정. reader.error를 우선 사용하고, 제출 catch 블록도 비-Error 값에 안전하도록 보강.